### PR TITLE
package: Set `mean.js` as main in `pacakge.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@kelda/mean",
+  "main": "mean.js",
   "version": "0.0.1",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
The default entry point to the package is `index.js`, since
we don't have an `index.js`, this patch sets `mean.js` as the
`main` of the package.